### PR TITLE
fixes homebrew errors during update, closes #25

### DIFF
--- a/lib/exogenesis/passengers/homebrew.rb
+++ b/lib/exogenesis/passengers/homebrew.rb
@@ -27,9 +27,7 @@ class Homebrew < Passenger
     if outdated_packages == 0
       info "Brews", "All up to date"
     else
-      outdated_packages.each do |package|
-        execute "Upgrade #{package}", "brew upgrade #{package}"
-      end
+      execute "Upgrade #{outdated_packages.join(", ")}", "brew upgrade #{outdated_packages.join(" ")}"
     end
   end
 


### PR DESCRIPTION
Now the upgrade calls all outdated packages in one line. Maybe we should just update the packages that are known in the package.json and remove unknown packages?
