### PR TITLE
Python Passenger updated? :crying_cat_face:

### DIFF
--- a/spec/unit/python_spec.rb
+++ b/spec/unit/python_spec.rb
@@ -3,47 +3,62 @@ require "exogenesis/passengers/python"
 
 describe Python do
   let(:config) { double}
-  before { allow(config).to receive(:pips).and_return(pips) }
-
+  before { allow(config).to receive(:pips).and_return(required_pips) }
   let(:executor) { executor_double }
-  let(:pips) { ["pygments"] }
 
   subject { Python.new(config, executor) }
 
-  describe :setup do
-    it "should install python via homebrew and then link it with overwrite" do
-      executor.should_receive(:execute).ordered.with("Install Python", "brew install python")
-      executor.should_receive(:execute).ordered.with("Link Python", "brew link --overwrite python")
-      subject.setup
-    end
-
-    it "should skip if python is already installed" do
-      executor.stub(:execute).with("Install Python", "brew install python").and_yield "already installed"
-      expect { subject.setup }.to raise_exception(TaskSkipped, "Already installed")
-    end
-  end
-
-  describe :install do
-    it "should install the pips provided when initialized" do
-      executor.should_receive(:execute).with("Install pygments", "pip install --user pygments")
-      subject.install
-    end
-
-    it "should skip if the package was already installed" do
-      executor.stub(:execute).with("Install pygments", "pip install --user pygments").and_yield "already satisfied"
-      expect { subject.install }.to raise_exception(TaskSkipped, "Already installed")
-    end
-  end
-
   describe :up do
-    it "should update the pips provided when initialized" do
-      executor.should_receive(:execute).with("Update pygments", "pip install --user --upgrade pygments")
-      subject.up
+    before do
+      allow(executor).to receive(:command_exists?).and_return(true)
+      allow(executor).to receive(:silent_execute).with('pip list').and_return(installed_pips)
     end
 
-    it "should skip the package if it is already up to date" do
-      executor.stub(:execute).with("Update pygments", "pip install --user --upgrade pygments").and_yield "already up-to-date"
-      expect { subject.up }.to raise_exception(TaskSkipped, "Already up to date")
+    let(:required_pips) { ['pygments', 'buildbot'] }
+    let(:installed_pips) { "buildbot (0.8.8)\nbuildbot-slave (0.8.8)" }
+
+    describe 'installing Python' do
+      context 'when pip already exists' do
+        before { allow(executor).to receive(:command_exists?).and_return(true) }
+
+        it 'should skip installing Python' do
+          expect(executor).to receive(:skip_task).with('Install Python')
+          subject.up
+        end
+
+        it 'should not install Python via brew' do
+          expect(executor).to_not receive(:execute).with('Install Python', 'brew install python')
+          subject.up
+        end
+      end
+
+      context 'when pip does not exist' do
+        before { allow(executor).to receive(:command_exists?).and_return(false) }
+
+        it 'should install Python via brew' do
+          expect(executor).to receive(:execute).with('Install Python', 'brew install python')
+          subject.up
+        end
+      end
+    end
+
+    describe 'link Python' do
+      it 'should link Python' do
+        expect(executor).to receive(:execute).with('Link Python', 'brew link --overwrite python')
+        subject.up
+      end
+
+      it 'should skip the task if it is already linked' do
+        allow(executor).to receive(:execute).with('Link Python', 'brew link --overwrite python').and_yield('Warning: Already linked: /usr/local/Cellar/python/2.7.6')
+        expect { subject.up }.to raise_exception(TaskSkipped, 'Already linked')
+      end
+    end
+
+    describe 'installing and updating pips' do
+      it 'should update pip itself'
+      it 'should update installed pips' # Update buildbot
+      it 'should install missing pips'  # Install pygments
+      it 'should skip the update if it is up to date'
     end
   end
 end


### PR DESCRIPTION
I started updating the Python Passenger, and I made good progress. But then I wanted to try it out on my system and my Python is totally and utterly borked. I mean really freaking broken. It explodes.

The steps are quite easy:
1. `brew install python` (or `brew install python3`)
2. You could overwrite system python (maybe this was a mistake)
3. `pip` (or `pip3`) is now available
4. `pip install --upgrade pip` (or `pip3 install --upgrade pip`)
5. Use `pip list` (or `pip3 list`) to list installed pips to decide if they need to be updated or installed

That's basically it. There's also the possibility of using the `--user` flag.

But I can't really try it...

I updated most of the spec suite, just a few pending ones left.

I don't use Python for anything right now. I noticed you do, @bitboxer (for pygments).
If you have time next week, could you look into this? Try it out?
