### PR TITLE
Some fonts have spaces in the name

### DIFF
--- a/lib/exogenesis/passengers/fonts.rb
+++ b/lib/exogenesis/passengers/fonts.rb
@@ -34,7 +34,7 @@ class Fonts < Passenger
     if File.exist? target_font_path(file)
       skip_task "Copying #{File.basename file}", 'Already copied'
     else
-      execute "Copying #{File.basename file}", "cp #{file} #{target_font_path(file)}"
+      execute "Copying #{File.basename file}", "cp '#{file}' '#{target_font_path(file)}'"
     end
   end
 

--- a/spec/unit/fonts_spec.rb
+++ b/spec/unit/fonts_spec.rb
@@ -24,9 +24,9 @@ describe Fonts do
 
     it 'should copy fonts if they are not found' do
       expect(executor).to receive(:execute)
-        .with('Copying roboto.ttf', "cp #{config.fonts_path}/roboto.ttf #{ENV['HOME']}/Library/Fonts/roboto.ttf")
+        .with('Copying roboto.ttf', "cp '#{config.fonts_path}/roboto.ttf' '#{ENV['HOME']}/Library/Fonts/roboto.ttf'")
       expect(executor).to receive(:execute)
-        .with('Copying bignoodle.otf', "cp #{config.fonts_path}/bignoodle.otf #{ENV['HOME']}/Library/Fonts/bignoodle.otf")
+        .with('Copying bignoodle.otf', "cp '#{config.fonts_path}/bignoodle.otf' '#{ENV['HOME']}/Library/Fonts/bignoodle.otf'")
       subject.up
     end
 


### PR DESCRIPTION
To be able to copy files with spaces I added some quotes to the cp command :wink:

I could also use Shellescape to do this if you prefer.